### PR TITLE
Fix Payload to Google Books API to request 40 results

### DIFF
--- a/app.py
+++ b/app.py
@@ -60,7 +60,7 @@ def search():
     payload = {
         'key': os.environ['GOOGLE_BOOKS_KEY'],
         'q': f'{type}{q}',
-        'maxResults': 5
+        'maxResults': 40
     }
     search = SearchFacade(payload)
     book_collection = search.books()


### PR DESCRIPTION
Co-authored-by: Rachel Lew <48839191+rlew421@users.noreply.github.com>
Co-authored-by: Madelyn Romero <51763489+madelynrr@users.noreply.github.com>

#### This PR is a
- [ ] feature
- [x] bug fix
- [ ] refactor
#### What does this PR do?
Fixes bug where only 5 results were returned from a Google Books API request

#### Where should the reviewer start?
`/search` endpoint in `app.py`. Specifically in the payload

#### If applicable, how should this be manually tested?
Check `/search` endpoint and verify that 40 results are returned

#### Any background context you want to provide?
A maximum of 5 was returned in previous build to aid in debugging

#### What are the relevant tickets?
closes #18 

#### Questions or Next Steps:

#### PR Gif
![breadcrumbs](https://user-images.githubusercontent.com/53122061/78842723-1158c980-79be-11ea-9fb8-ca2da13173c4.gif)

