### PR TITLE
Refactor to change valid query params

### DIFF
--- a/app.py
+++ b/app.py
@@ -53,15 +53,7 @@ def search():
         return build_preflight_response()
     elif request.method == 'GET':
         req = request.get_json()
-        type = request.args.get('type')
-        q = request.args.get('q')
-        payload = {
-            'key':          os.environ['GOOGLE_BOOKS_KEY'],
-            'q':            f'{type}{q}',
-            'maxResults':   40,
-            'printType':    'books'
-        }
-        search = SearchFacade(payload)
+        search = SearchFacade(request.args)
         book_collection = search.books()
         serializer = BookSerializer(many = True)
         result = serializer.dump(book_collection)
@@ -81,4 +73,4 @@ def build_actual_response(response):
     return response
 
 if __name__ == '__main__':
-     app.run()
+    app.run()

--- a/services.py
+++ b/services.py
@@ -22,9 +22,9 @@ class GoogleBooksService():
 
 		payload = {
 			'key':          os.environ['GOOGLE_BOOKS_KEY'],
-        	'q':            f'{type}{query}',
+			'q':            f'{type}{query}',
 			'maxResults':   40,
 			'printType':    'books'
-        }
+		}
 		response = requests.get('https://www.googleapis.com/books/v1/volumes', params = payload)
 		return json.loads(response.content)

--- a/services.py
+++ b/services.py
@@ -1,5 +1,6 @@
 import requests
 import json
+import os
 
 class GoogleBooksService():
 	def __init__(self, query):
@@ -7,5 +8,23 @@ class GoogleBooksService():
 
 
 	def get_json(self):
-		response = requests.get('https://www.googleapis.com/books/v1/volumes', params = self.query)
+		type = self.query.get('type')
+		if type == 'author':
+			type = 'inauthor:'
+		elif type == 'title':
+			type = 'intitle:'
+		elif type == 'genre':
+			type = 'subject:'
+		elif type == 'isbn':
+			type = 'isbn:'
+
+		query = self.query.get('q')
+
+		payload = {
+			'key':          os.environ['GOOGLE_BOOKS_KEY'],
+        	'q':            f'{type}{query}',
+			'maxResults':   40,
+			'printType':    'books'
+        }
+		response = requests.get('https://www.googleapis.com/books/v1/volumes', params = payload)
 		return json.loads(response.content)


### PR DESCRIPTION
#### This PR is a
- [ ] feature
- [ ] bug fix
- [x] refactor
#### What does this PR do?
Fix how BE receives and formats params to pass to Google Books API

#### Where should the reviewer start?
`app.py` and `services.py`. Note how payload is now created in service class and should be receiving `type` params as `author`, `title`, `isbn`, and `genre` to be converted to the proper string for Google Books API query.

#### If applicable, how should this be manually tested?
Check endpoint with new param values

#### Any background context you want to provide?
After check-in with PMs, it was noted how closely tied FE params were coupled with the Google Books API. This change makes the API dynamic enough to account for other APIs we may want to query in the future

#### What are the relevant tickets?
#27 

#### Questions or Next Steps:
@vladd-png will need to update how the params are passed in from FE

#### PR Gif
![shrug](https://user-images.githubusercontent.com/53122061/78956537-d4650380-7a9f-11ea-8259-46bed9530875.gif)

