### PR TITLE
Add Coverage Package

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,5 @@
+[report]
+omit =
+  env/*
+  tests/*
+  config.py

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-# vs cdoe settings
+# vs code settings
 .vscode
 
 # env settings
@@ -9,3 +9,10 @@ env
 
 # pycache
 *.pyc
+
+# test coverage files
+.coverage
+htmlcov
+
+# trash
+.ds_store

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ attrs==19.3.0
 certifi==2019.11.28
 chardet==3.0.4
 click==7.1.1
+coverage==5.0.4
 Flask==1.1.1
 Flask-GraphQL==2.0.1
 Flask-Migrate==2.5.3

--- a/tests/app_test.py
+++ b/tests/app_test.py
@@ -13,5 +13,8 @@ class TestApp(unittest.TestCase):
 		self.assertEqual(200, response.status_code)
 
 	def test_search_endpoint(self):
-		response = self.app.get('/search?type=inauthor:&q=george rr martin')
+		response = self.app.get('/search?type=author&q=george rr martin')
 		self.assertEqual(200, response.status_code)
+
+		json_data = json.loads(response.data)
+		self.assertEqual(40, len(json_data.get('data')))


### PR DESCRIPTION
#### This PR is a
- [ ] feature
- [ ] bug fix
- [ ] refactor
- [x] chore

#### What does this PR do?
Adds coverage package and config to check test coverage

#### Where should the reviewer start?
Start by running `pip install -r requirements.txt`. To see coverage results, run `coverage report`. To generate HTML files like simplecov does, run `coverage html`. To access the detailed reports, run `open htmlcov`. In this folder, you can see the detailed reports for each `.py file`

#### Any background context you want to provide?
![Screen Shot 2020-04-10 at 10 05 50 AM](https://user-images.githubusercontent.com/53122061/79006289-12047380-7b16-11ea-8299-febadba0b568.png)

![Screen Shot 2020-04-10 at 10 29 29 AM](https://user-images.githubusercontent.com/53122061/79006339-2e081500-7b16-11ea-9b78-ef466ce21490.png)

#### What are the relevant tickets?
closes #11 

#### Questions or Next Steps:
Increase coverage by adding testing for `/graphql` endpoint

#### PR Gif
![tired](https://user-images.githubusercontent.com/53122061/79006449-690a4880-7b16-11ea-9899-6ef991e9c84b.gif)
