### PR TITLE
Refactor Book POPO

### DIFF
--- a/app.py
+++ b/app.py
@@ -56,8 +56,8 @@ def search():
         return build_preflight_response()
     elif request.method == 'GET':
         req = request.get_json()
-        search = SearchFacade(request.args)
-        book_collection = search.books()
+        search = SearchFacade.from_query(request.args)
+        book_collection = search.books
         serializer = BookSerializer(many = True)
         result = serializer.dump(book_collection)
         return build_actual_response(jsonify(result))

--- a/facades.py
+++ b/facades.py
@@ -2,18 +2,16 @@ from services import *
 from popos import *
 
 class SearchFacade():
-	def	__init__(self, query):
+	def	__init__(self, query, books=[]):
 		self.id = None
 		self.query = query
+		self.books = books
 
+	@classmethod
+	def from_query(cls, query):
+		service = GoogleBooksService(query)
+		books = []
+		for book in service.get_json()['items']:
+			books.append(Book.from_google_response(book))
 
-	def books(self):
-		collection = []
-		for book in self.service().get_json()['items']:
-			collection.append(Book(book))
-
-		return collection
-
-
-	def	service(self):
-		return GoogleBooksService(self.query)
+		return cls(query, books)

--- a/popos.py
+++ b/popos.py
@@ -9,22 +9,39 @@ class Genre:
 
 
 class Book:
-	def __init__(self, object):
-		self.title = object['volumeInfo'].setdefault('title', '')
-		self.description = object['volumeInfo'].setdefault('description', '')
-		self.published_date = object['volumeInfo'].setdefault('publishedDate', '')
+	def __init__(self, title, description, published_date, image_url, isbn, authors, genres):
+		self.title = title
+		self.description = description
+		self.published_date = published_date
+		self.isbn = isbn
+		self.image_url = image_url
+		self.authors = authors
+		self.genres = genres
 
-		if 'imageLinks' in object['volumeInfo']:
-			self.image_url = object['volumeInfo']['imageLinks'].setdefault('thumbnail', '')
+	@classmethod
+	def from_google_response(cls, payload):
+		book_data = payload['volumeInfo']
+
+		title = book_data.setdefault('title', '')
+		description = book_data.setdefault('description', '')
+		published_date = book_data.setdefault('publishedDate', '')
+
+		if 'industryIdentifiers' in book_data:
+			isbn = book_data['industryIdentifiers'][0].setdefault('identifier', '')
 		else:
-			self.image_url = ''
+			isbn = ''
 
-		self.author_list = object['volumeInfo'].setdefault('authors', [])
-		self.authors = []
-		for author in self.author_list:
-			self.authors.append(Author(name=author))
+		if 'imageLinks' in book_data:
+			image_url = book_data['imageLinks'].setdefault('thumbnail', '')
+		else:
+			image_url = ''
 
-		self.genre_list = object['volumeInfo'].setdefault('categories', [])
-		self.genres = []
-		for genre in self.genre_list:
-			self.genres.append(Genre(type=genre))
+		authors = []
+		for author in book_data.setdefault('authors', []):
+			authors.append(Author(name=author))
+
+		genres = []
+		for genre in book_data.setdefault('categories', []):
+			genres.append(Genre(type=genre))
+
+		return cls(title, description, published_date, image_url, isbn, authors, genres)

--- a/serializers.py
+++ b/serializers.py
@@ -21,6 +21,7 @@ class BookSerializer(Schema):
     title = fields.String()
     description = fields.String()
     published_date = fields.String()
+    isbn = fields.String()
     image_url = fields.String()
     authors = fields.Nested(AuthorSerializer(), many=True)
     genres = fields.Nested(GenreSerializer(), many=True)


### PR DESCRIPTION
#### This PR is a
- [ ] feature
- [ ] bug fix
- [x] refactor

#### What does this PR do?
Refactors Book POPO to more closely align with Python convention. Uses a class method to define a custom constructor to create SearchFacade and Book objects from a Google Books request.
Also adds ISBN to `/search` request

#### Where should the reviewer start?
`popos.py` - Book objects can now be created with the custom constructor `from_google_response` which takes a payload dictionary. Instead of passing that payload dictionary into a Book like `Book(payload)` (old line 13 in old `facades.py`), a new Book should now be created from the Google Books response using `Book.from_google_response(payload)` (line 15 in `facades.py`). 

`facades.py` - Similarly, a SearchFacade should now be constructed with the `from_query` constructor in `app.py`, which defines books as an attribute instead of a method (line 59 & 60 in both versions of `app.py`).  

The above refactors should make these classes more 'pythonic' (align with python convention). `__init__` now defines all the object's attributes, and the `from_query` and `from_google_response` methods return a new object using the attributes defined in the constructor.

`serializers.py` - Additionally, ISBNs should now be returned in a `/search` request.

#### If applicable, how should this be manually tested?
Hit the `/search` endpoint using your favorite parameters. The response should be identical and in addition, return an ISBN number.

#### Any background context you want to provide?
@madelynrr - This seems to be a cleaner way to define attributes than what we had originally come up with.

#### What are the relevant tickets?
closes #33 

#### Questions or Next Steps:

#### PR Gif
![scott pilgrim gets it](https://user-images.githubusercontent.com/53122061/79047899-b9e17600-7bd6-11ea-93ec-5186225e0ffb.gif)
