### PR TITLE
Patch request for book

### DIFF
--- a/app.py
+++ b/app.py
@@ -112,6 +112,18 @@ def create_book():
             return build_actual_response(jsonify(result))
 
 
+@app.route('/switch_shelves', methods=['OPTIONS', 'PATCH'])
+def switch_shelves():
+    if request.method == 'OPTIONS':
+        return build_preflight_response()
+    elif request.method == 'PATCH':
+        isbn = request.args.get('isbn')
+        book = db.session.query(BookModel).filter_by(isbn=isbn).first()
+        book.shelves.pop(0)
+        shelf = db.session.query(ShelfModel).filter_by(id=1).first()
+        book.shelves.append(shelf)
+
+
 def build_preflight_response():
     response = make_response()
     response.headers.add("Access-Control-Allow-Origin", "*")

--- a/app.py
+++ b/app.py
@@ -123,6 +123,11 @@ def switch_shelves():
         shelf = db.session.query(ShelfModel).filter_by(id=1).first()
         book.shelves.append(shelf)
 
+        db.session.commit()
+        serializer = BookSerializer()
+        result = serializer.dump(book)
+        return build_actual_response(jsonify(result))
+
 
 def build_preflight_response():
     response = make_response()


### PR DESCRIPTION
#### This PR is a
- [x] feature
- [ ] bug fix
- [ ] refactor

#### What does this PR do?
Creates a patch endpoint to switch a book from shelf 2 (to read) to shelf 1 (already read).

#### Where should the reviewer start?
Start in app.py at /switch_shelves route

#### If applicable, how should this be manually tested?
Can run app locally and test through Postman by creating a book, and then updating the shelf with a url such as, where the isbn is the same as a created book's isbn:
http://localhost:5000/switch_shelves?isbn=1

#### Any background context you want to provide?
The app is currently functioning such that the only time a book would switch shelves would be from "to read" to "already read."

#### What are the relevant tickets?
Closes #46 

#### Questions or Next Steps:
Needs to be refactored out.
For future iterations, would need to be reworked once there are multiple users with multiple shelves.

#### PR Gif
![image](https://i.pinimg.com/originals/10/98/96/1098968b81867e6015fb46ebca41a63b.gif)
