### PR TITLE
Set default shelf to "to read" shelf when book is added

### DIFF
--- a/app.py
+++ b/app.py
@@ -73,9 +73,6 @@ def create_book():
             return build_actual_response(jsonify(result))
         else:
             params = request.args
-            shelf_id = params.get('shelf_id')
-            shelf = ShelfModel.query.filter_by(id=shelf_id).first()
-
             author_names = params.getlist('author')
             authors = []
             for author_name in author_names:
@@ -104,6 +101,7 @@ def create_book():
             image_url = params.get('image_url')
             isbn = params.get('isbn')
             published_date = params.get('published_date')
+            shelf = ShelfModel.query.filter_by(id=2).first()
             book = BookModel(title=title, summary=summary, image_url=image_url, isbn=isbn, published_date=published_date, authors=authors, genres=genres, shelves=[shelf])
             db.session.add(book)
             db.session.commit()


### PR DESCRIPTION
Co-Authored-By: Madelyn Romero <51763489+madelynrr@users.noreply.github.com>

#### This PR is a
- [ ] feature
- [ ] bug fix
- [x] refactor

#### What does this PR do?
- When a user adds a book to a shelf, adds it to the "to read" shelf by default

#### Where should the reviewer start?
```
app.py
```

#### If applicable, how should this be manually tested?
Run server with ```flask run```, open Postman and make a POST request to this URL:
```
http://localhost:5000/create_book?author=Stephen King&genre=horror&title=IT&isbn=3748920374983&date_published=June 7 1987&summary=Pennywise is creepy&image_url=http://image_url.jpg
```
Open Postico and see that the book has been created in the books table. Check the book_shelves joins table and see that the book was automatically placed on shelf 2.

#### Any background context you want to provide?
We made a separate branch and PR for this small refactor so that Virginia can test this on the frontend.

#### What are the relevant tickets?
N/A

#### Questions or Next Steps:
Virginia can test this functionality on the frontend.

#### PR Gif
![gif alt](https://pics.me.me/when-he-says-i-will-change-for-you-m-owaahh-35446393.png)
