### PR TITLE
Set default shelf so a book is added to "to read" shelf by default, a…

### DIFF
--- a/app.py
+++ b/app.py
@@ -73,8 +73,7 @@ def create_book():
             return build_actual_response(jsonify(result))
         else:
             params = request.args
-            shelf_id = params.get('shelf_id')
-            shelf = ShelfModel.query.filter_by(id=shelf_id).first()
+            shelf = ShelfModel.query.filter_by(id=2).first()
 
             author_names = params.getlist('author')
             authors = []
@@ -123,6 +122,7 @@ def switch_shelves():
         shelf = db.session.query(ShelfModel).filter_by(id=1).first()
         book.shelves.append(shelf)
 
+        db.session.add(book)
         db.session.commit()
         serializer = BookSerializer()
         result = serializer.dump(book)


### PR DESCRIPTION
…dd book to session in switch_shelves function

Co-Authored-By: Madelyn Romero <51763489+madelynrr@users.noreply.github.com>

#### This PR is a
- [ ] feature
- [ ] bug fix
- [x] refactor

#### What does this PR do?
Sets default shelf to "to read" so when user adds a book, it is added to "to read" by default.

#### Where should the reviewer start?
```
app.py
```

#### If applicable, how should this be manually tested?
Run server with ```flask run```, open Postman and make a POST request to this URL:
```
http://localhost:5000/create_book?author=Stephen King&genre=horror&title=IT&isbn=3748920374983&date_published=June 7 1987&summary=Pennywise is creepy&image_url=http://image_url.jpg
```
Open Postico and see that the book has been created in the books table. Check the book_shelves joins table and see that the book was automatically placed on shelf 2.

#### Any background context you want to provide?
This change was previously included in a refactor PR that was reverted. We implemented this small change and made a new PR.

#### What are the relevant tickets?
N/A

#### Questions or Next Steps:
Virginia can test if she can add a book to a shelf on the frontend.

#### PR Gif
![gif alt](https://i.imgur.com/3tcJ70q.gif)
