### PR TITLE
Get book images from OpenLibrary Covers API and reassign a book's ima…

### DIFF
--- a/facades.py
+++ b/facades.py
@@ -7,11 +7,15 @@ class SearchFacade():
 		self.query = query
 		self.books = books
 
+
 	@classmethod
 	def from_query(cls, query):
 		service = GoogleBooksService(query)
 		books = []
 		for book in service.get_json()['items']:
-			books.append(Book.from_google_response(book))
+			new_book = Book.from_google_response(book)
+			url = "http://covers.openlibrary.org/b/isbn/{}-M.jpg".format(new_book.isbn)
+			new_book.image_url = url
+			books.append(new_book)
 
 		return cls(query, books)


### PR DESCRIPTION
…ge_url

Co-Authored-By: Madelyn Romero <51763489+madelynrr@users.noreply.github.com>

#### This PR is a
- [ ] feature
- [ ] bug fix
- [x] refactor

#### What does this PR do?
This PR reassigns the image_url to the url provided by the OpenLibrary Covers API.

#### Where should the reviewer start?
```
facades.py
```

#### If applicable, how should this be manually tested?
On the frontend, search for a book by title, save it to bookshelf, and see that the book and its image both appear in the "to read" shelf.

#### Any background context you want to provide?
Previously, the GoogleBooks API was returning images for most books; however, GoogleBooks wasn't allowing us to save many of the cover images for the books to our database. We think it may have something to do on Google's end. We found another API to which we can pass a book's isbn and retrieve a cover image. OpenLibrary doesn't return an image for every book, but it will return an image for most books. Hopefully this will allow us to save the image when we add a book to a shelf.

#### What are the relevant tickets?

#### Questions or Next Steps:
Have Virginia test this on the frontend.

#### PR Gif
![gif alt](https://media1.giphy.com/media/bJtt2VRXNy6ze/source.gif)
Sometimes the API can't find one.
