### PR TITLE
Revert "Get book images from OpenLibrary Covers API and reassign a book's ima…"

### DIFF
--- a/facades.py
+++ b/facades.py
@@ -7,15 +7,11 @@ class SearchFacade():
 		self.query = query
 		self.books = books
 
-
 	@classmethod
 	def from_query(cls, query):
 		service = GoogleBooksService(query)
 		books = []
 		for book in service.get_json()['items']:
-			new_book = Book.from_google_response(book)
-			url = "http://covers.openlibrary.org/b/isbn/{}-M.jpg".format(new_book.isbn)
-			new_book.image_url = url
-			books.append(new_book)
+			books.append(Book.from_google_response(book))
 
 		return cls(query, books)


### PR DESCRIPTION
Reverts BookBasket/book_basket_BE#60

We're reverting this PR because although OpenLibrary Covers API allows the book cover image to be preserved when we save a book to a shelf, it returns far fewer results (book cover images) than Google Books.